### PR TITLE
refactor: move startup process to a Deployment

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -31,5 +31,3 @@ EXPOSE 443/tcp 992/tcp 5555/tcp
 # 起動スクリプトの追加
 COPY start.sh /start.sh
 RUN chmod +x /start.sh
-
-CMD ["/start.sh"]

--- a/manifest/softether/deployment.yaml
+++ b/manifest/softether/deployment.yaml
@@ -19,3 +19,4 @@ spec:
         image: ghcr.io/honahuku/softether:4.38.9760
         ports:
         - containerPort: 443
+        command: ["/start.sh"]


### PR DESCRIPTION
dockerfileで定義されていたstartスクリプト実行の記述をk8s manifestに移す
同じイメージを使ってネットワーク疎通確認など検証を行うpodを建てたいのでその対応